### PR TITLE
fix(changelog): Fix commit group order

### DIFF
--- a/src/steps/changelog.ts
+++ b/src/steps/changelog.ts
@@ -3,7 +3,7 @@ import * as stream from 'stream';
 
 import * as conventionalChangelog from 'conventional-changelog';
 
-import { changelogTransformer } from './../templates/changelog-transform';
+import { changelogTransformer, changelogCommitGroupsSort } from './../templates/changelog-transform';
 import { log } from './../log';
 import { readFile } from './../utilities/read-file';
 import { writeFile } from './../utilities/write-file';
@@ -53,11 +53,12 @@ function generateChangelog( changelogTemplates: { [ key: string ]: string },repo
 		}, {
 			linkCompare: false // We use a custom link
 		}, {}, {}, {
-			transform: changelogTransformer( repositoryUrl ), // Custom transform (shows all commit types)
-			mainTemplate: changelogTemplates.mainTemplate,
+			commitGroupsSort: changelogCommitGroupsSort,
 			commitPartial: changelogTemplates.commitTemplate,
+			footerPartial: changelogTemplates.footerTemplate,
 			headerPartial: changelogTemplates.headerTemplate,
-			footerPartial: changelogTemplates.footerTemplate
+			mainTemplate: changelogTemplates.mainTemplate,
+			transform: changelogTransformer( repositoryUrl ) // Custom transform (shows all commit types)
 		} );
 
 		// Handle errors

--- a/src/steps/github.ts
+++ b/src/steps/github.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as githubReleaser from 'conventional-github-releaser';
 import * as githubRemoveAllReleases from 'github-remove-all-releases';
 
-import { changelogTransformer } from './../templates/changelog-transform';
+import { changelogTransformer, changelogCommitGroupsSort } from './../templates/changelog-transform';
 import { log } from './../log';
 import { readChangelogTemplateFiles } from './changelog';
 
@@ -53,11 +53,12 @@ function createGithubReleases( changelogTemplates: { [ key: string ]: string }, 
 		}, {
 			linkCompare: false // We use a custom link
 		}, {}, {}, {
-			transform: changelogTransformer( repositoryUrl ), // Custom transform (shows all commit types)
-			mainTemplate: changelogTemplates.mainTemplate,
+			commitGroupsSort: changelogCommitGroupsSort,
 			commitPartial: changelogTemplates.commitTemplate,
+			footerPartial: changelogTemplates.footerTemplate,
 			headerPartial: '', // No header for release notes
-			footerPartial: changelogTemplates.footerTemplate
+			mainTemplate: changelogTemplates.mainTemplate,
+			transform: changelogTransformer( repositoryUrl ) // Custom transform (shows all commit types)
 		}, ( error: Error | null, response: any ) => { // We do not care about the response
 
 			// Catch library errors

--- a/src/templates/changelog-transform.ts
+++ b/src/templates/changelog-transform.ts
@@ -18,6 +18,11 @@ export const commitTypes: { [ type: string ]: string } = {
 };
 
 /**
+ * Ordered commit type titles, used for sorting (pre-calculated here for #perf reasons)
+ */
+export const commitTypesOrder: Array<string> = Object.values( commitTypes );
+
+/**
  * Changelog transformer, primarily enhancing the commit content text
  */
 export function changelogTransformer( repositoryUrl: string ) {
@@ -71,4 +76,11 @@ export function changelogTransformer( repositoryUrl: string ) {
 
 	};
 
+};
+
+/**
+ * Changelog commit group sort function
+ */
+export function changelogCommitGroupsSort( a: any, b: any ) {
+	return commitTypesOrder.indexOf( a.title ) > commitTypesOrder.indexOf( b.title );
 };

--- a/test/end-to-end.spec.ts
+++ b/test/end-to-end.spec.ts
@@ -237,13 +237,13 @@ describe( 'Automatic Release: end-to-end', () => {
 			expect( changelogContent.length ).toBe( 29 );
 			expect( changelogContent[ 0 ] ).toBe( `## [${ expectedSecondRelease }](${ initialPackageJson.repository.url }/releases/tag/${ expectedSecondRelease }) (${ today })` );
 			expect( changelogContent[ 1 ] ).toBe( '' );
-			expect( changelogContent[ 2 ] ).toBe( '### Bug Fixes' );
+			expect( changelogContent[ 2 ] ).toBe( '### Features' );
 			expect( changelogContent[ 3 ] ).toBe( '' );
-			testChangelogChange( changelogContent[ 4 ], commits[ 4 ], initialPackageJson.repository.url );
+			testChangelogChange( changelogContent[ 4 ], commits[ 5 ], initialPackageJson.repository.url );
 			expect( changelogContent[ 5 ] ).toBe( '' );
-			expect( changelogContent[ 6 ] ).toBe( '### Features' );
+			expect( changelogContent[ 6 ] ).toBe( '### Bug Fixes' );
 			expect( changelogContent[ 7 ] ).toBe( '' );
-			testChangelogChange( changelogContent[ 8 ], commits[ 5 ], initialPackageJson.repository.url );
+			testChangelogChange( changelogContent[ 8 ], commits[ 4 ], initialPackageJson.repository.url );
 
 			expect( changelogContent[ 9 ] ).toBe( '' );
 			expect( changelogContent[ 10 ] ).toBe( '<br>' );
@@ -309,13 +309,13 @@ describe( 'Automatic Release: end-to-end', () => {
 
 			// Check changelog content
 			expect( githubSecondReleaseContent.length ).toBe( 8 );
-			expect( githubSecondReleaseContent[ 0 ] ).toBe( '### Bug Fixes' );
+			expect( githubSecondReleaseContent[ 0 ] ).toBe( '### Features' );
 			expect( githubSecondReleaseContent[ 1 ] ).toBe( '' );
-			testChangelogChange( githubSecondReleaseContent[ 2 ], commits[ 4 ], initialPackageJson.repository.url );
+			testChangelogChange( githubSecondReleaseContent[ 2 ], commits[ 5 ], initialPackageJson.repository.url );
 			expect( githubSecondReleaseContent[ 3 ] ).toBe( '' );
-			expect( githubSecondReleaseContent[ 4 ] ).toBe( '### Features' );
+			expect( githubSecondReleaseContent[ 4 ] ).toBe( '### Bug Fixes' );
 			expect( githubSecondReleaseContent[ 5 ] ).toBe( '' );
-			testChangelogChange( githubSecondReleaseContent[ 6 ], commits[ 5 ], initialPackageJson.repository.url );
+			testChangelogChange( githubSecondReleaseContent[ 6 ], commits[ 4 ], initialPackageJson.repository.url );
 			expect( githubSecondReleaseContent[ 7 ] ).toBe( '' );
 
 			// Check changelog details


### PR DESCRIPTION
- Fix commit group order, now preferring interesting information (e.g. features, bug fixes) over not-so-interesting ones (e.g. tests, docs)